### PR TITLE
Problem: Wei.getFiat() can not handle rate with more than 15 s.d.

### DIFF
--- a/lib/wei.js
+++ b/lib/wei.js
@@ -122,7 +122,7 @@
       value: function getFiat(r) {
         var decimals = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
 
-        var rate = r === null || typeof r === 'undefined' ? ZERO : new _bignumber2.default(r);
+        var rate = r === null || typeof r === 'undefined' ? ZERO : new _bignumber2.default(r.toString());
         return this.value().dividedBy(ETHER).mul(rate).toFixed(decimals);
       }
     }]);

--- a/lib/wei.js.flow
+++ b/lib/wei.js.flow
@@ -63,7 +63,7 @@ export default class Wei {
   getFiat(r: number, decimals: number = 2): string {
     const rate = (r === null || typeof r === 'undefined') ?
       ZERO :
-      new BigNumber(r);
+      new BigNumber(r.toString());
     return this.value().dividedBy(ETHER).mul(rate).toFixed(decimals);
   }
 }

--- a/src/wei.js
+++ b/src/wei.js
@@ -63,7 +63,7 @@ export default class Wei {
   getFiat(r: number, decimals: number = 2): string {
     const rate = (r === null || typeof r === 'undefined') ?
       ZERO :
-      new BigNumber(r);
+      new BigNumber(r.toString());
     return this.value().dividedBy(ETHER).mul(rate).toFixed(decimals);
   }
 }

--- a/src/wei.test.js
+++ b/src/wei.test.js
@@ -19,3 +19,7 @@ test('getFiat() default rate is 0', () => {
   expect(new Wei(1000010000000000000).getFiat(null)).toEqual('0.00');
 });
 
+test('getFiat() when rate has more than 15 s.d.', () => {
+  expect(new Wei(100000000000000000).getFiat(114.12768558799999)).toEqual('11.41');
+})
+


### PR DESCRIPTION
Solution: Before BigNumber construction we convert number to string